### PR TITLE
Fix CI issues with Python version

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate HTML
         run: |
@@ -24,7 +24,7 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: '_build/html'
 

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - name: Checkout

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -25,6 +25,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get install libopenblas-dev
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest tox-gh-actions
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -25,7 +25,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get install libopenblas-dev
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest tox-gh-actions
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -25,7 +25,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get install -y python3-distutils
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest tox-gh-actions
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -25,6 +25,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        apt-get install python3-distutils
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest tox-gh-actions
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        apt-get install python3-distutils
+        sudo apt-get install -y python3-distutils
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest tox-gh-actions
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -21,7 +21,6 @@ jobs:
 
       - name: Run pytest
         run: |
-          sudo apt-get install libopenblas-dev
           pip install pytest pytest-cov
           pip install -r requirements.txt
           pytest --cov=./ --cov-report=xml

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: 3.11
 
       - name: Run pytest
         run: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Run pytest
         run: |
+          sudo apt-get install libopenblas-dev
           pip install pytest pytest-cov
           pip install -r requirements.txt
           pytest --cov=./ --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.26.1
-pandas==2.0.3
-pyarrow==12.0.*
+numpy==1.26.*
+pandas==2.*
+pyarrow==13.0.*
 pytest==7.3.1
 pytest-cov==4.1.0
 scipy==1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.25.1
+numpy==1.26.1
 pandas==2.0.3
 pyarrow==12.0.*
 pytest==7.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pandas==2.*
 pyarrow==13.0.*
 pytest==7.3.1
 pytest-cov==4.1.0
-scipy==1.11.1
+scipy==1.11.*
 setuptools==59.6.0
 statsmodels==0.14.0


### PR DESCRIPTION
This PR fixes CI issues uncovered by #16.

Took me awhile to debug, but the `setup-python` GitHub Action switched to using `3.12` in this most recent PR (since we didn't have the setup action version locked). Unfortunately, most of the package dependencies we're using [do not yet have `3.12` wheels on PyPI](https://github.com/apache/arrow/issues/37880). This resulted in build failures from trying to build from source while lacking system dependencies.