### PR TITLE
Switch MKI sorting from quicksort to mergesort

### DIFF
--- a/assesspy/formulas.py
+++ b/assesspy/formulas.py
@@ -176,7 +176,7 @@ def prb(assessed, sale_price, round=None):
 # Calculate the Gini cofficients needed for KI and MKI
 def calculate_gini(assessed, sale_price):
     df = pd.DataFrame({"av": assessed, "sp": sale_price})
-    df = df.sort_values(by="sp")
+    df = df.sort_values(by="sp", kind="mergesort")  # for stable sort results
     assessed_price = df["av"].values
     sale_price = df["sp"].values
     n = len(assessed_price)


### PR DESCRIPTION
While working on https://github.com/ccao-data/data-architecture/pull/422, I discovered that `mki()` doesn't produce stable results i.e. it returns slightly different values for each run. This is due to the default `pandas.sort_values()` function using quicksort, which is [not stable](https://en.wikipedia.org/wiki/Category:Stable_sorts) and returns different index orders for ties.

Per this [SO post](https://stackoverflow.com/questions/19580900/how-is-pandas-deciding-order-in-a-sort-when-there-is-a-tie), This PR switches the sort method to mergesort, which is stable.