### PR TITLE
Cache pages builds

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -42,8 +42,16 @@ jobs:
         with:
           limit-access-to-actor: true
 
+      - name: Install and run git-restore-mtime
+        shell: bash
+        run: |
+          apt-get update
+          apt-get install git-restore-mtime -y
+          git-restore-mtime
+
       - name: Generate HTML
-        run: uv run sphinx-build -d _build/doctrees docs/source _build/html
+        run: |
+          uv run sphinx-build -j auto -d _build/doctrees docs/source _build/html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -37,11 +37,6 @@ jobs:
       - name: Install Python dependencies
         run: uv pip install .[docs]
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true
-
       - name: Generate HTML
         run: |
           uv run sphinx-build -j auto \

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -37,6 +37,11 @@ jobs:
       - name: Install Python dependencies
         run: uv pip install .[docs]
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+
       - name: Generate HTML
         run: uv run sphinx-build -d _build/doctrees docs/source _build/html
 

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -20,6 +20,13 @@ jobs:
       - name: Configure pages
         uses: actions/configure-pages@v5
 
+      - uses: actions/cache@v4
+        with:
+          path: |
+            _build/html
+            _build/doctrees
+          key: pages-${{ runner.os }}-${{ hashFiles('docs/**') }}
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -23,9 +23,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: |
-            _build/html
-            _build/doctrees
-          key: pages-${{ runner.os }}-${{ hashFiles('docs/**') }}
+            _build/.jupyter_cache
+            _build/jupyter_execute
+          key: pages-${{ runner.os }}-${{ hashFiles('docs/source/notebooks/**') }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -42,21 +42,15 @@ jobs:
         with:
           limit-access-to-actor: true
 
-      - name: Install and run git-restore-mtime
-        shell: bash
-        run: |
-          apt-get update
-          apt-get install git-restore-mtime -y
-          git-restore-mtime
-
       - name: Generate HTML
         run: |
-          uv run sphinx-build -j auto -d _build/doctrees docs/source _build/html
+          uv run sphinx-build -j auto \
+            -d _build/doctrees docs/source _build/html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: "_build/html"
+          path: _build/html
 
   deploy:
     if: contains(fromJSON('["main", "master"]'), github.ref_name) && github.event_name != 'pull_request'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,3 +14,4 @@ source_suffix = {".rst": "restructuredtext", ".ipynb": "myst-nb"}
 nb_render_image_options = {"width": "450px", "align": "center"}
 nb_execution_timeout = 600
 html_sidebars = {"**": []}
+jupyter_execute_notebooks = "cache"


### PR DESCRIPTION
This PR adds caching for our pages build, since it takes awhile and currently runs on every PR commit. I couldn't get sphinx caching to work (it seems to somehow rely on [the modified time of files](https://github.com/sphinx-doc/sphinx/issues/11556)), but caching the jupyter notebook build works fine and brings the build from ~3 minutes to <20 seconds.