### PR TITLE
Add median ratio met

### DIFF
--- a/assesspy/__init__.py
+++ b/assesspy/__init__.py
@@ -18,7 +18,7 @@ from .metrics import (
     prb_met,
     prd,
     prd_met,
-    median_ratio_met
+    med_ratio_met
 )
 from .outliers import is_outlier
 from .sales_chasing import is_sales_chased

--- a/assesspy/__init__.py
+++ b/assesspy/__init__.py
@@ -18,6 +18,7 @@ from .metrics import (
     prb_met,
     prd,
     prd_met,
+    median_ratio_met
 )
 from .outliers import is_outlier
 from .sales_chasing import is_sales_chased

--- a/assesspy/__init__.py
+++ b/assesspy/__init__.py
@@ -12,13 +12,13 @@ from .metrics import (
     cod,
     cod_met,
     ki,
+    med_ratio_met,
     mki,
     mki_met,
     prb,
     prb_met,
     prd,
     prd_met,
-    med_ratio_met
 )
 from .outliers import is_outlier
 from .sales_chasing import is_sales_chased

--- a/assesspy/metrics.py
+++ b/assesspy/metrics.py
@@ -334,6 +334,31 @@ def ki(
 
 
 # Functions to determine whether IAAO/Quintos fairness criteria is met
+
+def median_ratio_met(x: float) -> bool:
+    """
+    Check whether median_ratio meets IAAO standards (between .9 and 1.1, inclusive).
+
+    :param x: A single float value containing the median_ratio.
+    :type x: float
+
+    :return: A boolean value indicating whether the median_ratio meets IAAO standards.
+    :rtype: bool
+    """
+    return .9 < x <= 1.1
+
+def vertical_equity_met(prd: float, prb: float) -> bool:
+    """
+    Check whether vertical equity meets IAAO standards:
+    - PRD should be between 0.98 and 1.03 (inclusive).
+    - PRB should be between -0.05 and +0.05 (inclusive).
+
+    :param prd: A single float value for the Price-Related Differential (PRD).
+    :param prb: A single float value for the Price-Related Bias (PRB).
+    :return: A boolean value indicating whether either PRD or PRB meets IAAO standards.
+    """
+    return 0.98 <= prd <= 1.03 or -0.05 <= prb <= 0.05
+
 def cod_met(x: float) -> bool:
     """
     Check whether COD meets IAAO standards (between 5 and 15, inclusive).

--- a/assesspy/metrics.py
+++ b/assesspy/metrics.py
@@ -347,18 +347,6 @@ def median_ratio_met(x: float) -> bool:
     """
     return .9 < x <= 1.1
 
-def vertical_equity_met(prd: float, prb: float) -> bool:
-    """
-    Check whether vertical equity meets IAAO standards:
-    - PRD should be between 0.98 and 1.03 (inclusive).
-    - PRB should be between -0.05 and +0.05 (inclusive).
-
-    :param prd: A single float value for the Price-Related Differential (PRD).
-    :param prb: A single float value for the Price-Related Bias (PRB).
-    :return: A boolean value indicating whether either PRD or PRB meets IAAO standards.
-    """
-    return 0.98 <= prd <= 1.03 or -0.05 <= prb <= 0.05
-
 def cod_met(x: float) -> bool:
     """
     Check whether COD meets IAAO standards (between 5 and 15, inclusive).

--- a/assesspy/metrics.py
+++ b/assesspy/metrics.py
@@ -345,7 +345,7 @@ def med_ratio_met(x: float) -> bool:
     :return: A boolean value indicating whether the median_ratio meets IAAO standards.
     :rtype: bool
     """
-    return .9 < x <= 1.1
+    return 0.9 < x <= 1.1
 
 def cod_met(x: float) -> bool:
     """

--- a/assesspy/metrics.py
+++ b/assesspy/metrics.py
@@ -335,6 +335,7 @@ def ki(
 
 # Functions to determine whether IAAO/Quintos fairness criteria is met
 
+
 def med_ratio_met(x: float) -> bool:
     """
     Check whether median_ratio meets IAAO standards (between .9 and 1.1, inclusive).
@@ -346,6 +347,7 @@ def med_ratio_met(x: float) -> bool:
     :rtype: bool
     """
     return 0.9 < x <= 1.1
+
 
 def cod_met(x: float) -> bool:
     """

--- a/assesspy/metrics.py
+++ b/assesspy/metrics.py
@@ -335,7 +335,7 @@ def ki(
 
 # Functions to determine whether IAAO/Quintos fairness criteria is met
 
-def median_ratio_met(x: float) -> bool:
+def med_ratio_met(x: float) -> bool:
     """
     Check whether median_ratio meets IAAO standards (between .9 and 1.1, inclusive).
 

--- a/docs/source/med_ratio_met.rst
+++ b/docs/source/med_ratio_met.rst
@@ -1,0 +1,5 @@
+================================================
+Test if median ratio meets IAAO standards
+================================================
+
+.. autofunction:: assesspy.median_ratio_met

--- a/docs/source/med_ratio_met.rst
+++ b/docs/source/med_ratio_met.rst
@@ -2,4 +2,4 @@
 Test if median ratio meets IAAO standards
 ================================================
 
-.. autofunction:: assesspy.median_ratio_met
+.. autofunction:: assesspy.med_ratio_met

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -79,6 +79,9 @@ Other functions
 
 :doc:`is_outlier() <outliers>`
 
+| Calculate if median_ratio is within the acceptable range
+:doc: median_ratio_met() <median_ratio_met>
+
 
 Data
 ----

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -81,7 +81,7 @@ Other functions
 
 | Calculate if median_ratio is within the acceptable range
 
-:doc: `med_ratio_met() <med_ratio_met>`
+:doc:`med_ratio_met() <med_ratio_met>`
 
 
 Data

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -80,7 +80,8 @@ Other functions
 :doc:`is_outlier() <outliers>`
 
 | Calculate if median_ratio is within the acceptable range
-:doc: median_ratio_met() <median_ratio_met>
+
+:doc: `med_ratio_met() <med_ratio_met>`
 
 
 Data


### PR DESCRIPTION
This adds median ratio to assesspy to allow for updated tables in reporting.

First step in [737](https://github.com/ccao-data/data-architecture/issues/737).

Put this in all location where mki_met was.