### PR TITLE
Bump to version 2.0.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,6 +2,6 @@ message: "If you use this software, please cite it as below."
 authors:
 - family-names: "Cook County Assessor's Office"
 title: "AssessPy"
-version: 2.0.1
+version: 2.0.2
 date-released: 2022-11-14
 url: https://github.com/ccao-data/assesspy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "assesspy"
-version = "2.0.1"
+version = "2.0.2"
 description = "Python package for measuring assessment performance"
 keywords = ["assessment", "property taxes", "local government"]
 authors = [


### PR DESCRIPTION
Version bump for [`med_ratio_met`](https://github.com/ccao-data/assesspy/blob/16f6c671bac14215a806d7316a53e9a14241d8dc/assesspy/metrics.py#L339-L349) function.