### PR TITLE
Upgrade `pypa/gh-action-pypi-publish` to v1.14.1

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -28,4 +28,4 @@ jobs:
         run: uv build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.1


### PR DESCRIPTION
[v1.14.1](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.1) of `pypa/gh-action-pypi-publish` upgrades a dependency to fully migrate away from the deprecated version of Node that inspired our work in https://github.com/ccao-data/assesspy/pull/35. To complete that effort, we upgrade to v1.14.1.

I didn't actually test this change, because I don't want to push to PyPI and we don't have a test PyPI environment set up for this workflow. But it's a minor version upgrade of the dependency, so in theory it should just be a drop-in replacement.